### PR TITLE
Improve model path resolution for Babylon example

### DIFF
--- a/example.html
+++ b/example.html
@@ -54,8 +54,9 @@
             // Default intensity is 1. Let's dim the light a small amount
             light.intensity = 0.7;
             
-            // Load meshes
-            BABYLON.SceneLoader.ImportMeshAsync("", "/models/", "scene.babylon");
+            // Load meshes from a path that works no matter where this page is hosted
+            const modelsRootUrl = new URL("./models/", window.location.href).href;
+            BABYLON.SceneLoader.ImportMeshAsync("", modelsRootUrl, "scene.babylon", scene);
             
             return scene;
         };


### PR DESCRIPTION
## Summary
- compute the models directory URL dynamically from the page location
- load the Babylon scene into the existing scene using the computed URL so it works from any subdirectory

## Testing
- python3 -m http.server 8000 --bind 0.0.0.0 (served /workspace and loaded http://127.0.0.1:8000/jsproject/example.html)

------
https://chatgpt.com/codex/tasks/task_e_68df1dfd45fc8324aaaec6ec29840ab4